### PR TITLE
support trimpath

### DIFF
--- a/zapgorm2.go
+++ b/zapgorm2.go
@@ -92,8 +92,10 @@ func (l Logger) Trace(ctx context.Context, begin time.Time, fc func() (string, i
 }
 
 var (
-	gormPackage    = filepath.Join("gorm.io", "gorm")
-	zapgormPackage = filepath.Join("moul.io", "zapgorm2")
+	gormPackage            = filepath.Join("gorm.io", "gorm")
+	zapgormPackage         = filepath.Join("moul.io", "zapgorm2")
+	gormPackageTrimPath    = "gorm@"
+	zapgormPackageTrimPath = "zapgorm2@"
 )
 
 func (l Logger) logger(ctx context.Context) *zap.Logger {
@@ -110,6 +112,8 @@ func (l Logger) logger(ctx context.Context) *zap.Logger {
 		case strings.HasSuffix(file, "_test.go"):
 		case strings.Contains(file, gormPackage):
 		case strings.Contains(file, zapgormPackage):
+		case strings.HasPrefix(file, gormPackageTrimPath):
+		case strings.HasPrefix(file, zapgormPackageTrimPath):
 		default:
 			return logger.WithOptions(zap.AddCallerSkip(i))
 		}


### PR DESCRIPTION
<!--
Thank you for your contribution to this repo!

Before submitting a pull request, please check the following:
- reference any related issue, PR, link
- use the "WIP" title prefix if you need help or more time to finish your PR

you can remove this markdown comment
-->

When compiling with `--trimpath` (which is very common nowadays), the file path will looks very different. An example of that would be:

```
gorm@v1.24.3/finisher_api.go:609 the log message
```

This pull request should be able to take care of that.